### PR TITLE
fix(git): allow Sync to commit when the dotfiles repo has no remote (#7)

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -118,7 +118,7 @@ func repoHasRemote(dir string) bool {
 	cmd.Dir = dir
 	out, err := cmd.Output()
 	if err != nil {
-		// Treat any error as "no remote" — the existing pull/push code
+		// Treat any error as "no remote", the existing pull/push code
 		// would have surfaced it anyway. False is the conservative answer.
 		return false
 	}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -29,17 +29,27 @@ func Sync(cfg config.Config) error {
 		return fmt.Errorf("directory %s is not a git repository", dotfilesDir)
 	}
 
+	// A repository without any configured remote can still be a meaningful
+	// dotfiles store (e.g. local-only experiments before pushing to a host).
+	// Skip the pull/push round-trips entirely in that case so the local
+	// commit still happens (#7).
+	hasRemote := repoHasRemote(dotfilesDir)
+
 	// 1. Pull changes first using rebase and autostash.
 	// This ensures we have the latest remote changes and helps avoid merge commits.
-	if err := pull(dotfilesDir); err != nil {
-		if isRebasing(dotfilesDir) {
-			utils.PrintMessage("Conflicts detected during pull. Applying strategy:", cfg.SyncStrategy)
-			if err := resolveRebase(dotfilesDir, cfg.SyncStrategy); err != nil {
-				return fmt.Errorf("failed to resolve conflicts: %w. Please resolve manually", err)
+	if hasRemote {
+		if err := pull(dotfilesDir); err != nil {
+			if isRebasing(dotfilesDir) {
+				utils.PrintMessage("Conflicts detected during pull. Applying strategy:", cfg.SyncStrategy)
+				if err := resolveRebase(dotfilesDir, cfg.SyncStrategy); err != nil {
+					return fmt.Errorf("failed to resolve conflicts: %w. Please resolve manually", err)
+				}
+			} else {
+				return fmt.Errorf("failed to pull changes: %w. Please resolve conflicts manually", err)
 			}
-		} else {
-			return fmt.Errorf("failed to pull changes: %w. Please resolve conflicts manually", err)
 		}
+	} else {
+		utils.PrintMessage("No git remote configured; skipping pull.")
 	}
 
 	utils.PrintMessage("Checking for changes in", dotfilesDir)
@@ -85,14 +95,34 @@ func Sync(cfg config.Config) error {
 		return fmt.Errorf("failed to commit: %w", err)
 	}
 
-	// 4. Push the new commit to the remote repository.
-	utils.PrintMessage("Pushing changes...")
-	if err := push(dotfilesDir); err != nil {
-		return fmt.Errorf("failed to push: %w", err)
+	// 4. Push the new commit to the remote repository (only if there is one).
+	if hasRemote {
+		utils.PrintMessage("Pushing changes...")
+		if err := push(dotfilesDir); err != nil {
+			return fmt.Errorf("failed to push: %w", err)
+		}
+	} else {
+		utils.PrintMessage("No git remote configured; skipping push.")
 	}
 
 	utils.PrintMessage("Sync completed successfully")
 	return nil
+}
+
+// repoHasRemote returns true if the dotfiles git repository has at least
+// one named remote (e.g. `origin`). When no remotes are configured the
+// caller should skip pull/push and still allow the local commit, so a
+// remote-less local-only repo is a usable dotfiles store (#7).
+func repoHasRemote(dir string) bool {
+	cmd := exec.Command("git", "remote")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		// Treat any error as "no remote" — the existing pull/push code
+		// would have surfaced it anyway. False is the conservative answer.
+		return false
+	}
+	return strings.TrimSpace(string(out)) != ""
 }
 
 // isRepo determines whether the specified directory path resides within a valid git work tree.

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,0 +1,38 @@
+package git
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestRepoHasRemote_NoRemote pins the regression for #7: a fresh git
+// repo with no configured remote must report repoHasRemote == false so
+// Sync's pull/push guards skip those round-trips and still allow the
+// local commit to land.
+func TestRepoHasRemote_NoRemote(t *testing.T) {
+	dir := t.TempDir()
+	if err := exec.Command("git", "-C", dir, "init", "-q", "-b", "main").Run(); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	if got := repoHasRemote(dir); got {
+		t.Fatalf("repoHasRemote on remote-less repo = true, want false")
+	}
+}
+
+// TestRepoHasRemote_WithRemote sanity: once a remote is configured the
+// helper reports true. Uses the repo's own .git directory as a dummy
+// remote URL so the test has no network dependency.
+func TestRepoHasRemote_WithRemote(t *testing.T) {
+	dir := t.TempDir()
+	if err := exec.Command("git", "-C", dir, "init", "-q", "-b", "main").Run(); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	if err := exec.Command("git", "-C", dir, "remote", "add", "origin",
+		filepath.Join(dir, ".git")).Run(); err != nil {
+		t.Fatalf("git remote add: %v", err)
+	}
+	if got := repoHasRemote(dir); !got {
+		t.Fatalf("repoHasRemote on repo with `origin` = false, want true")
+	}
+}


### PR DESCRIPTION
Closes #7.

## What

`Sync` was calling `git pull --rebase --autostash` and `git push`
unconditionally. When the dotfiles repo has no remote configured
(e.g. a local-only experiment before pushing to GitHub), both fail
and `Sync` returned a hard error, so the local commit never ran
either, even though the issue explicitly says "foondot should still
commit without the pull and push actions" in that case.

## Fix

- New `repoHasRemote(dir) bool` helper that runs `git remote` and
  returns true only when at least one remote is configured (any git
  error → conservative `false`).
- `Sync` now gates the pull and push calls on `repoHasRemote`. The
  stage / commit / generate-message pipeline runs as before.
- A short `utils.PrintMessage` line announces the skip on each side
  so users can see why no network round-trips happened.

End-to-end on a remote-less repo: `Sync` now just produces the local
commit and exits cleanly.

## Tests

`internal/git/git_test.go` (new):

- `TestRepoHasRemote_NoRemote`, fresh `git init` repo, expect false
  (the #7 regression).
- `TestRepoHasRemote_WithRemote`, `git remote add origin <path>`,
  expect true. Uses the repo's own `.git` directory as the dummy
  remote URL, so the test has no network dependency.

## Verification

- `go build ./...` ✅
- `go test ./internal/git/...` → 2 passed.